### PR TITLE
Adds rotation to shapes and groups

### DIFF
--- a/config/layout10.xml
+++ b/config/layout10.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<layout>
+    <size width="800" height="240"/>
+    <channels count="16"/>
+    <background red="75" green="75" blue="75" />
+    <elements>
+        <shape type="rect" name="Channel 0" x="10" y="10" width="40" height="80" red="255" green="255" blue="255" fill="false" channel="0" />
+        <shape type="rect" name="Channel 1" x="100" y="10" width="40" height="80" red="0" green="255" blue="0" fill="true" channel="1" />
+        <shape type="rect" name="Channel 2" x="10" y="100" width="40" height="80" red="255" green="255" blue="255" fill="false" channel="2" />
+        <shape type="rect" name="Channel 3" x="100" y="100" width="40" height="80" red="0" green="255" blue="0" fill="true" channel="3" />
+    </elements>
+</layout>

--- a/config/layout11.xml
+++ b/config/layout11.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<layout>
+    <size width="800" height="240"/>
+    <channels count="16"/>
+    <background red="75" green="75" blue="75" />
+    <elements>
+        <group x="400" y="100" rotation="-45">
+            <shape type="fan" name="Channels 0 - 6 Fan" x="10" y="10" width="160" height="80" channel="0">
+                <spoke red="255" green="255" blue="255"/>
+                <spoke red="0" green="0" blue="255"/>
+                <spoke red="255" green="255" blue="255"/>
+                <spoke red="0" green="0" blue="255"/>
+                <spoke red="255" green="255" blue="255"/>
+                <spoke red="0" green="0" blue="255"/>
+                <spoke red="255" green="255" blue="255"/>
+            </shape>
+            <shape type="megatree" name="Channels 0 - 6 Megatree" x="210" y="10" rotation="45" width="100" height="80" channel="0">
+                <spoke red="255" green="0" blue="0"/>
+                <spoke red="0" green="255" blue="0"/>
+                <spoke red="255" green="0" blue="0"/>
+                <spoke red="0" green="255" blue="0"/>
+                <spoke red="255" green="0" blue="0"/>
+                <spoke red="0" green="255" blue="0"/>
+                <spoke red="255" green="0" blue="0"/>
+            </shape>
+            <shape type="text" name="Channel 8" x="-50" y="0"
+            red="255" green="127" blue="127" font="Helvetica"
+            fontSize="30" channel="1">
+                Hello world!
+            </shape>
+        </group>
+        <shape type="rect" name="Channel 0" x="10" y="10" width="80" height="80" red="255" green="255" blue="255" fill="false" channel="0" />
+        <shape type="rect" name="Channel 1" x="100" y="10" width="80" height="80" red="0" green="255" blue="0" fill="true" channel="1" />
+        <shape type="oval" name="Channel 2" x="190" y="10" width="80" height="60" red="255" green="128" blue="0" fill="false" channel="2" />
+        <shape type="oval" name="Channel 3" x="280" y="10" width="80" height="60" red="255" green="0" blue="0" fill="true" channel="3" />
+        <shape type="oval" name="Channel 4" x="370" y="10" width="40" height="60" red="0" green="255" blue="255" fill="false" channel="4" />
+        <shape type="oval" name="Channel 5" x="460" y="10" width="40" height="60" red="255" green="0" blue="255" fill="true" channel="5" />
+        <shape type="arc" name="Channel 6" x="550" y="10" width="40" height="60" red="0" green="187" blue="0" fill="false" start="90" size="270" channel="6" />
+        <shape type="arc" name="Channel 7" x="640" y="10" width="40" height="60" red="255" green="255" blue="0" fill="true" start="90" size="90" channel="7" />
+        <shape type="arc" name="Channel 8" x="10" y="100" width="80" height="40" red="255" green="255" blue="255" fill="false" start="-90" size="90" channel="8" />
+        <shape type="rect" name="Channel 9" x="100" y="100" width="80" height="80" red="0" green="255" blue="0" fill="true" channel="9" />
+        <shape type="rect" name="Channel 10" x="190" y="100" width="80" height="80" red="255" green="128" blue="0" fill="false" channel="10" />
+        <shape type="rect" name="Channel 11" x="280" y="100" width="80" height="80" red="255" green="0" blue="0" fill="true" channel="11" />
+        <shape type="rect" name="Channel 12" x="370" y="100" width="80" height="80" red="0" green="255" blue="255" fill="false" channel="12" />
+        <shape type="rect" name="Channel 13" x="460" y="100" width="80" height="80" red="255" green="0" blue="255" fill="true" channel="13" />
+        <shape type="rect" name="Channel 14" x="550" y="100" width="80" height="80" red="0" green="187" blue="0" fill="false" channel="14" />
+        <shape type="rect" name="Channel 15" x="640" y="100" width="80" height="80" red="255" green="255" blue="0" fill="true" channel="15" />
+    </elements>
+</layout>

--- a/config/layout11.xml
+++ b/config/layout11.xml
@@ -4,46 +4,17 @@
     <channels count="16"/>
     <background red="75" green="75" blue="75" />
     <elements>
-        <group x="400" y="100" rotation="-45">
-            <shape type="fan" name="Channels 0 - 6 Fan" x="10" y="10" width="160" height="80" channel="0">
-                <spoke red="255" green="255" blue="255"/>
-                <spoke red="0" green="0" blue="255"/>
-                <spoke red="255" green="255" blue="255"/>
-                <spoke red="0" green="0" blue="255"/>
-                <spoke red="255" green="255" blue="255"/>
-                <spoke red="0" green="0" blue="255"/>
-                <spoke red="255" green="255" blue="255"/>
-            </shape>
-            <shape type="megatree" name="Channels 0 - 6 Megatree" x="210" y="10" rotation="45" width="100" height="80" channel="0">
-                <spoke red="255" green="0" blue="0"/>
-                <spoke red="0" green="255" blue="0"/>
-                <spoke red="255" green="0" blue="0"/>
-                <spoke red="0" green="255" blue="0"/>
-                <spoke red="255" green="0" blue="0"/>
-                <spoke red="0" green="255" blue="0"/>
-                <spoke red="255" green="0" blue="0"/>
-            </shape>
-            <shape type="text" name="Channel 8" x="-50" y="0"
-            red="255" green="127" blue="127" font="Helvetica"
-            fontSize="30" channel="1">
-                Hello world!
-            </shape>
+        <group x="50" y="10">
+            <shape type="rect" name="Channel 0" x="0" y="0" width="90" height="90" red="255" green="255" blue="255" fill="false" channel="0" />
+            <shape type="rect" name="Channel 1" x="100" y="10" width="80" height="80" red="0" green="255" blue="0" fill="true" channel="1" />
+            <shape type="rect" name="Channel 2" x="10" y="100" width="80" height="80" red="255" green="255" blue="255" fill="false" channel="2" />
+            <shape type="rect" name="Channel 3" x="100" y="100" width="80" height="80" red="0" green="255" blue="0" fill="true" channel="3" />
         </group>
-        <shape type="rect" name="Channel 0" x="10" y="10" width="80" height="80" red="255" green="255" blue="255" fill="false" channel="0" />
-        <shape type="rect" name="Channel 1" x="100" y="10" width="80" height="80" red="0" green="255" blue="0" fill="true" channel="1" />
-        <shape type="oval" name="Channel 2" x="190" y="10" width="80" height="60" red="255" green="128" blue="0" fill="false" channel="2" />
-        <shape type="oval" name="Channel 3" x="280" y="10" width="80" height="60" red="255" green="0" blue="0" fill="true" channel="3" />
-        <shape type="oval" name="Channel 4" x="370" y="10" width="40" height="60" red="0" green="255" blue="255" fill="false" channel="4" />
-        <shape type="oval" name="Channel 5" x="460" y="10" width="40" height="60" red="255" green="0" blue="255" fill="true" channel="5" />
-        <shape type="arc" name="Channel 6" x="550" y="10" width="40" height="60" red="0" green="187" blue="0" fill="false" start="90" size="270" channel="6" />
-        <shape type="arc" name="Channel 7" x="640" y="10" width="40" height="60" red="255" green="255" blue="0" fill="true" start="90" size="90" channel="7" />
-        <shape type="arc" name="Channel 8" x="10" y="100" width="80" height="40" red="255" green="255" blue="255" fill="false" start="-90" size="90" channel="8" />
-        <shape type="rect" name="Channel 9" x="100" y="100" width="80" height="80" red="0" green="255" blue="0" fill="true" channel="9" />
-        <shape type="rect" name="Channel 10" x="190" y="100" width="80" height="80" red="255" green="128" blue="0" fill="false" channel="10" />
-        <shape type="rect" name="Channel 11" x="280" y="100" width="80" height="80" red="255" green="0" blue="0" fill="true" channel="11" />
-        <shape type="rect" name="Channel 12" x="370" y="100" width="80" height="80" red="0" green="255" blue="255" fill="false" channel="12" />
-        <shape type="rect" name="Channel 13" x="460" y="100" width="80" height="80" red="255" green="0" blue="255" fill="true" channel="13" />
-        <shape type="rect" name="Channel 14" x="550" y="100" width="80" height="80" red="0" green="187" blue="0" fill="false" channel="14" />
-        <shape type="rect" name="Channel 15" x="640" y="100" width="80" height="80" red="255" green="255" blue="0" fill="true" channel="15" />
+        <group x="50" y="10" rotation="45">
+            <shape type="rect" name="Channel 0" x="0" y="0" width="90" height="90" red="255" green="255" blue="255" fill="false" channel="0" />
+            <shape type="rect" name="Channel 1" x="100" y="10" width="80" height="80" red="0" green="255" blue="0" fill="true" channel="1" />
+            <shape type="rect" name="Channel 2" x="10" y="100" width="80" height="80" red="255" green="255" blue="255" fill="false" channel="2" />
+            <shape type="rect" name="Channel 3" x="100" y="100" width="80" height="80" red="0" green="255" blue="0" fill="true" channel="3" />
+        </group>
     </elements>
 </layout>

--- a/config/layout11.xml
+++ b/config/layout11.xml
@@ -11,8 +11,8 @@
             <shape type="rect" name="Channel 3" x="100" y="100" width="80" height="80" red="0" green="255" blue="0" fill="true" channel="3" />
         </group>
         <group x="50" y="10" rotation="45">
-            <shape type="rect" name="Channel 0" x="0" y="0" width="90" height="90" red="255" green="255" blue="255" fill="false" channel="0" />
-            <shape type="rect" name="Channel 1" x="100" y="10" width="80" height="80" red="0" green="255" blue="0" fill="true" channel="1" />
+            <shape rotation="-45" type="rect" name="Channel 0" x="0" y="0" width="90" height="90" red="255" green="255" blue="255" fill="false" channel="0" />
+            <shape rotation="-45" type="rect" name="Channel 1" x="100" y="10" width="80" height="80" red="0" green="255" blue="0" fill="true" channel="1" />
             <shape type="rect" name="Channel 2" x="10" y="100" width="80" height="80" red="255" green="255" blue="255" fill="false" channel="2" />
             <shape type="rect" name="Channel 3" x="100" y="100" width="80" height="80" red="0" green="255" blue="0" fill="true" channel="3" />
         </group>

--- a/config/layout9.xml
+++ b/config/layout9.xml
@@ -251,7 +251,7 @@
         <!-- Inner Pole 1 -->
         <shape type="line" name="Inner Pole 1" x="150" y="105" x2="0" y2="90" blue="0" red="255" green="0" relative="true" channel="148" />
 
-        <!-- Fan 1 -->
+        <!-- Sunburst 1 -->
         <shape type="fan" name="Fan 1, Channels 153 - 159" x="200" y="200" width="100" height="100" channel="153">
             <spoke red="255" green="255" blue="255"/>
             <spoke red="255" green="255" blue="255"/>
@@ -290,7 +290,7 @@
             <shape type="rect" name="Bush 12 Red" x="553" y="3" width="50" height="100" red="255" green="0" blue="0" fill="true" channel="152" />
         </group>
 
-        <!-- Fan 2 -->
+        <!-- Sunburst 2 -->
         <shape type="fan" name="Fan 2, Channels 174,160-166" x="300" y="200" width="100" height="100" channel="160">
             <spoke red="255" green="0" blue="0"/>
             <spoke red="0" green="255" blue="0"/>
@@ -301,7 +301,7 @@
             <spoke red="255" green="0" blue="0"/>
         </shape>
 
-        <!-- Fan 3 -->
+        <!-- Sunburst 3 -->
         <shape type="fan" name="Fan 3, Channels 192-198" x="400" y="200" width="100" height="100" channel="192">
             <spoke red="255" green="255" blue="255"/>
             <spoke red="255" green="255" blue="255"/>
@@ -390,7 +390,7 @@
             <shape type="line" name="Inner Railing C2" x="10" y="70" x2="80" y2="0" blue="255" red="255" green="255" relative="true" channel="187" />
         </group>
 
-        <!-- Fan 4 -->
+        <!-- Sunburst 4 -->
         <shape type="fan" name="Fan 4, Channels 199-205" x="500" y="200" width="100" height="100" channel="199">
             <spoke red="255" green="0" blue="0"/>
             <spoke red="0" green="255" blue="0"/>
@@ -401,7 +401,7 @@
             <spoke red="255" green="0" blue="0"/>
         </shape>
 
-        <!-- Fan 5 -->
+        <!-- Sunburst 5 -->
         <shape type="fan" name="Fan 5, Channels 208-214" x="600" y="200" width="100" height="100" channel="208">
             <spoke red="255" green="255" blue="255"/>
             <spoke red="255" green="255" blue="255"/>
@@ -426,7 +426,7 @@
             </group>
         </group>
 
-        <!-- Fan 6 -->
+        <!-- Sunburst 6 -->
         <shape type="fan" name="Fan 6, Channels 215-221" x="700" y="200" width="100" height="100" channel="215">
             <spoke red="255" green="0" blue="0"/>
             <spoke red="0" green="255" blue="0"/>

--- a/src/net/teslaworks/visualizer/Group.java
+++ b/src/net/teslaworks/visualizer/Group.java
@@ -47,12 +47,14 @@ public class Group {
 
     public void paint(Graphics2D g2d, int[] channelValues) {
         g2d.translate(x, y);
+        g2d.rotate(rotation);
         for (Shape s : shapes) {
             s.paint(g2d, channelValues);
         }
         for (Group g : subgroups) {
             g.paint(g2d, channelValues);
         }
+        g2d.rotate(0 - rotation);
         g2d.translate(0 - x, 0 - y);
     }
 }

--- a/src/net/teslaworks/visualizer/Group.java
+++ b/src/net/teslaworks/visualizer/Group.java
@@ -13,14 +13,28 @@ public class Group {
     private final List<Shape> shapes;
     private final List<Group> subgroups;
     private final int x, y;
+    private final double rotation;
 
     @SuppressWarnings("unchecked")
     public Group(Element e) {
         this.shapes = new ArrayList<>();
         this.subgroups = new ArrayList<>();
 
-        x = Integer.parseInt(e.attributeValue("x"));
-        y = Integer.parseInt(e.attributeValue("y"));
+        int _x, _y;
+        double _rotation;
+
+        try { _x = Integer.parseInt(e.attributeValue("x")); }
+        catch (Exception r) { _x = 0; }
+
+        try { _y = Integer.parseInt(e.attributeValue("y")); }
+        catch (Exception r) { _y = 0; }
+
+        try { _rotation = Double.parseDouble(e.attributeValue("rotation")); }
+        catch (Exception r) { _rotation = 0; }
+
+        x = _x;
+        y = _y;
+        rotation = _rotation;
 
         for (Element shape : (List<Element>) e.elements("shape")) {
             shapes.add(Shape.makeShape(shape));

--- a/src/net/teslaworks/visualizer/Group.java
+++ b/src/net/teslaworks/visualizer/Group.java
@@ -10,15 +10,12 @@ import org.dom4j.Element;
 
 public class Group {
     
-    private final int xOffset, yOffset;
     private final List<Shape> shapes;
     private final List<Group> subgroups;
     private final int x, y;
 
     @SuppressWarnings("unchecked")
-    public Group(Element e, int _xOffset, int _yOffset) {
-        this.xOffset = _xOffset;
-        this.yOffset = _yOffset;
+    public Group(Element e) {
         this.shapes = new ArrayList<>();
         this.subgroups = new ArrayList<>();
 
@@ -26,20 +23,22 @@ public class Group {
         y = Integer.parseInt(e.attributeValue("y"));
 
         for (Element shape : (List<Element>) e.elements("shape")) {
-            shapes.add(Shape.makeShape(shape, x + xOffset, y + yOffset));
+            shapes.add(Shape.makeShape(shape));
         }
         
         for (Element subgroup : (List<Element>) e.elements("group")) {
-            subgroups.add(new Group(subgroup, x + xOffset, y + yOffset));
+            subgroups.add(new Group(subgroup));
         }
     }
 
     public void paint(Graphics2D g2d, int[] channelValues) {
+        g2d.translate(x, y);
         for (Shape s : shapes) {
             s.paint(g2d, channelValues);
         }
         for (Group g : subgroups) {
             g.paint(g2d, channelValues);
         }
+        g2d.translate(0 - x, 0 - y);
     }
 }

--- a/src/net/teslaworks/visualizer/LayoutXML.java
+++ b/src/net/teslaworks/visualizer/LayoutXML.java
@@ -43,9 +43,6 @@ public class LayoutXML {
         // Change top level 'elements' to a group node.
         Element elements = (Element) layout.selectSingleNode("/layout/elements");
         elements.setQName(new QName("group"));
-        elements.addAttribute("x", "0");
-        elements.addAttribute("y", "0");
-        elements.addAttribute("rotation", "0");
 
         // The top level group containing all the shapes and subgroups
         topGroup = new Group(elements);

--- a/src/net/teslaworks/visualizer/LayoutXML.java
+++ b/src/net/teslaworks/visualizer/LayoutXML.java
@@ -25,17 +25,16 @@ public class LayoutXML {
         Document layout = new SAXReader().read(layoutFile);;
 
         // Channel count
-        Element channels =
-                (Element) layout.selectSingleNode("/layout/channels");
-        channelValues =
-                new int[Integer.parseInt(channels.attributeValue("count"))];
+        Element channels = (Element) layout.selectSingleNode("/layout/channels");
+        channelValues = new int[Integer.parseInt(channels.attributeValue("count"))];
 
         // Window size and color
         Element sizeElement = (Element) layout.selectSingleNode("/layout/size");
         width = Integer.parseInt(sizeElement.attributeValue("width"));
         height = Integer.parseInt(sizeElement.attributeValue("height"));
-        Element bgElement =
-                (Element) layout.selectSingleNode("/layout/background");
+
+        // Background color
+        Element bgElement = (Element) layout.selectSingleNode("/layout/background");
         int bgRed = Integer.parseInt(bgElement.attributeValue("red"));
         int bgGreen = Integer.parseInt(bgElement.attributeValue("green"));
         int bgBlue = Integer.parseInt(bgElement.attributeValue("blue"));
@@ -48,6 +47,6 @@ public class LayoutXML {
         elements.addAttribute("y", "0");
         
         // The top level group containing all the shapes and subgroups
-        topGroup = new Group(elements, 0, 0);
+        topGroup = new Group(elements);
     }
 }

--- a/src/net/teslaworks/visualizer/LayoutXML.java
+++ b/src/net/teslaworks/visualizer/LayoutXML.java
@@ -45,7 +45,8 @@ public class LayoutXML {
         elements.setQName(new QName("group"));
         elements.addAttribute("x", "0");
         elements.addAttribute("y", "0");
-        
+        elements.addAttribute("rotation", "0");
+
         // The top level group containing all the shapes and subgroups
         topGroup = new Group(elements);
     }

--- a/src/net/teslaworks/visualizer/shapes/Arc.java
+++ b/src/net/teslaworks/visualizer/shapes/Arc.java
@@ -24,8 +24,7 @@ public class Arc extends Shape {
     }
 
     // Draw this arc
-    public void paint(Graphics2D g2d, int[] channelValues) {
-        super.paint(g2d, channelValues);
+    public void paintWork(Graphics2D g2d, int[] channelValues) {
         if (fill) {
             g2d.fillArc(x, y, width, height, start, size);
         }

--- a/src/net/teslaworks/visualizer/shapes/Arc.java
+++ b/src/net/teslaworks/visualizer/shapes/Arc.java
@@ -14,8 +14,8 @@ public class Arc extends Shape {
     public final boolean fill;
 
     // Set values unique to rectangles
-    protected Arc(Element e, int xOffset, int yOffset) {
-        super(e, xOffset, yOffset);
+    protected Arc(Element e) {
+        super(e);
         width = Integer.parseInt(e.attributeValue("width"));
         height = Integer.parseInt(e.attributeValue("height"));
         start = Integer.parseInt(e.attributeValue("start"));
@@ -27,10 +27,10 @@ public class Arc extends Shape {
     public void paint(Graphics2D g2d, int[] channelValues) {
         super.paint(g2d, channelValues);
         if (fill) {
-            g2d.fillArc(x + xOffset, y + yOffset, width, height, start, size);
+            g2d.fillArc(x, y, width, height, start, size);
         }
         else {
-            g2d.drawArc(x + xOffset, y + yOffset, width, height, start, size);
+            g2d.drawArc(x, y, width, height, start, size);
         }
     }
 }

--- a/src/net/teslaworks/visualizer/shapes/Line.java
+++ b/src/net/teslaworks/visualizer/shapes/Line.java
@@ -12,8 +12,8 @@ public class Line extends Shape {
     public final boolean relative;
 
     // Set values unique to rectangles
-    protected Line(Element e, int xOffset, int yOffset) {
-        super(e, xOffset, yOffset);
+    protected Line(Element e) {
+        super(e);
         x2 = Integer.parseInt(e.attributeValue("x2"));
         y2 = Integer.parseInt(e.attributeValue("y2"));
         relative = Boolean.parseBoolean(e.attributeValue("relative"));
@@ -23,10 +23,10 @@ public class Line extends Shape {
     public void paint(Graphics2D g2d, int[] channelValues) {
         super.paint(g2d, channelValues);
         if (relative) {
-            g2d.drawLine(x + xOffset, y + yOffset, x + x2 + xOffset, y + y2 + yOffset);
+            g2d.drawLine(x, y, x + x2, y + y2);
         }
         else {
-            g2d.drawLine(x + xOffset, y + yOffset, x2 + xOffset, y2 + yOffset);
+            g2d.drawLine(x, y, x2, y2);
         }
     }
 }

--- a/src/net/teslaworks/visualizer/shapes/Line.java
+++ b/src/net/teslaworks/visualizer/shapes/Line.java
@@ -20,8 +20,7 @@ public class Line extends Shape {
     }
 
     // Draw this line
-    public void paint(Graphics2D g2d, int[] channelValues) {
-        super.paint(g2d, channelValues);
+    public void paintWork(Graphics2D g2d, int[] channelValues) {
         if (relative) {
             g2d.drawLine(x, y, x + x2, y + y2);
         }

--- a/src/net/teslaworks/visualizer/shapes/Megatree.java
+++ b/src/net/teslaworks/visualizer/shapes/Megatree.java
@@ -57,8 +57,7 @@ public class Megatree extends Shape {
     }
 
     // Draw this fan
-    public void paint(Graphics2D g2d, int[] channelValues) {
-        super.paint(g2d, channelValues);
+    public void paintWork(Graphics2D g2d, int[] channelValues) {
         for (Spoke s : spokes) {
             g2d.setColor(new Color(s.red, s.green, s.blue, channelValues[s.channel]));
             g2d.drawLine(originX, y, s.endX, y + height);

--- a/src/net/teslaworks/visualizer/shapes/Megatree.java
+++ b/src/net/teslaworks/visualizer/shapes/Megatree.java
@@ -31,8 +31,8 @@ public class Megatree extends Shape {
     public final int originX;
     public final List<Spoke> spokes;
 
-    protected Megatree(Element e, int xOffset, int yOffset) {
-        super(e, xOffset, yOffset);
+    protected Megatree(Element e) {
+        super(e);
         
         width = Integer.parseInt(e.attributeValue("width"));
         height = Integer.parseInt(e.attributeValue("height"));
@@ -60,13 +60,8 @@ public class Megatree extends Shape {
     public void paint(Graphics2D g2d, int[] channelValues) {
         super.paint(g2d, channelValues);
         for (Spoke s : spokes) {
-            g2d.setColor(new Color(
-                    s.red, s.green, s.blue, channelValues[s.channel]));
-            g2d.drawLine(
-                    originX + xOffset,
-                    y + yOffset, 
-                    s.endX + xOffset,
-                    y + height + yOffset);
+            g2d.setColor(new Color(s.red, s.green, s.blue, channelValues[s.channel]));
+            g2d.drawLine(originX, y, s.endX, y + height);
         }
     }
 

--- a/src/net/teslaworks/visualizer/shapes/Oval.java
+++ b/src/net/teslaworks/visualizer/shapes/Oval.java
@@ -12,8 +12,8 @@ public class Oval extends Shape {
     public final boolean fill;
 
     // Set values unique to rectangles
-    protected Oval(Element e, int xOffset, int yOffset) {
-        super(e, xOffset, yOffset);
+    protected Oval(Element e) {
+        super(e);
         width = Integer.parseInt(e.attributeValue("width"));
         height = Integer.parseInt(e.attributeValue("height"));
         fill = Boolean.parseBoolean(e.attributeValue("fill"));
@@ -23,10 +23,10 @@ public class Oval extends Shape {
     public void paint(Graphics2D g2d, int[] channelValues) {
         super.paint(g2d, channelValues);
         if (fill) {
-            g2d.fillOval(x + xOffset, y + yOffset, width, height);
+            g2d.fillOval(x, y, width, height);
         }
         else {
-            g2d.drawOval(x + xOffset, y + yOffset, width, height);
+            g2d.drawOval(x, y, width, height);
         }
     }
 }

--- a/src/net/teslaworks/visualizer/shapes/Oval.java
+++ b/src/net/teslaworks/visualizer/shapes/Oval.java
@@ -20,8 +20,7 @@ public class Oval extends Shape {
     }
 
     // Draw this oval
-    public void paint(Graphics2D g2d, int[] channelValues) {
-        super.paint(g2d, channelValues);
+    public void paintWork(Graphics2D g2d, int[] channelValues) {
         if (fill) {
             g2d.fillOval(x, y, width, height);
         }

--- a/src/net/teslaworks/visualizer/shapes/Rectangle.java
+++ b/src/net/teslaworks/visualizer/shapes/Rectangle.java
@@ -20,8 +20,7 @@ public class Rectangle extends Shape {
     }
 
     // Draw this rectangle
-    public void paint(Graphics2D g2d, int[] channelValues) {
-        super.paint(g2d, channelValues);
+    public void paintWork(Graphics2D g2d, int[] channelValues) {
         if (fill) {
             g2d.fill(new java.awt.Rectangle(x, y, width, height));
         }

--- a/src/net/teslaworks/visualizer/shapes/Rectangle.java
+++ b/src/net/teslaworks/visualizer/shapes/Rectangle.java
@@ -23,10 +23,10 @@ public class Rectangle extends Shape {
     public void paint(Graphics2D g2d, int[] channelValues) {
         super.paint(g2d, channelValues);
         if (fill) {
-            g2d.fillRect(x + xOffset, y + yOffset, width, height);
+            g2d.fill(new java.awt.Rectangle(x + xOffset, y + yOffset, width, height));
         }
         else {
-            g2d.drawRect(x + xOffset, y + yOffset, width, height);
+            g2d.draw(new java.awt.Rectangle(x + xOffset, y + yOffset, width, height));
         }
     }
 }

--- a/src/net/teslaworks/visualizer/shapes/Rectangle.java
+++ b/src/net/teslaworks/visualizer/shapes/Rectangle.java
@@ -12,8 +12,8 @@ public class Rectangle extends Shape {
     public final boolean fill;
 
     // Set values unique to rectangles
-    protected Rectangle(Element e, int xOffset, int yOffset) {
-        super(e, xOffset, yOffset);
+    protected Rectangle(Element e) {
+        super(e);
         width = Integer.parseInt(e.attributeValue("width"));
         height = Integer.parseInt(e.attributeValue("height"));
         fill = Boolean.parseBoolean(e.attributeValue("fill"));
@@ -23,10 +23,10 @@ public class Rectangle extends Shape {
     public void paint(Graphics2D g2d, int[] channelValues) {
         super.paint(g2d, channelValues);
         if (fill) {
-            g2d.fill(new java.awt.Rectangle(x + xOffset, y + yOffset, width, height));
+            g2d.fill(new java.awt.Rectangle(x, y, width, height));
         }
         else {
-            g2d.draw(new java.awt.Rectangle(x + xOffset, y + yOffset, width, height));
+            g2d.draw(new java.awt.Rectangle(x, y, width, height));
         }
     }
 }

--- a/src/net/teslaworks/visualizer/shapes/Shape.java
+++ b/src/net/teslaworks/visualizer/shapes/Shape.java
@@ -15,8 +15,6 @@ public abstract class Shape {
     // Position
     public final int x;
     public final int y;
-    public final int xOffset;
-    public final int yOffset;
 
     // Color
     public final int red;
@@ -24,38 +22,36 @@ public abstract class Shape {
     public final int green;
 
     // Make a new shape from a <shape> tag in configuration
-    public static Shape makeShape(Element e, int xOffset, int yOffset) {
+    public static Shape makeShape(Element e) {
         // Switch based on "type" attribute in tag.
         String type = e.attributeValue("type");
         switch (type) {
         case "text":
-            return new Text(e, xOffset, yOffset);
+            return new Text(e);
         case "rect":
-            return new Rectangle(e, xOffset, yOffset);
+            return new Rectangle(e);
         case "oval":
-            return new Oval(e, xOffset, yOffset);
+            return new Oval(e);
         case "line":
-            return new Line(e, xOffset, yOffset);
+            return new Line(e);
         case "arc":
-            return new Arc(e, xOffset, yOffset);
+            return new Arc(e);
         case "fan": // Old name for Sunburst, here just in case.
         case "sunburst":
-            return new Sunburst(e, xOffset, yOffset);
+            return new Sunburst(e);
         case "megatree":
-            return new Megatree(e, xOffset, yOffset);
+            return new Megatree(e);
         }
         throw new IllegalArgumentException("Unknown shape type: " + e.asXML());
     }
 
     // Set values common to all shapes
-    protected Shape(Element e, int xOffset, int yOffset) {
+    protected Shape(Element e) {
         name = e.attributeValue("name");
         channel = Integer.parseInt(e.attributeValue("channel"));
 
         x = Integer.parseInt(e.attributeValue("x"));
         y = Integer.parseInt(e.attributeValue("y"));
-        this.xOffset = xOffset;
-        this.yOffset = yOffset;
 
         red = Integer.parseInt(e.attributeValue("red", "255"));
         blue = Integer.parseInt(e.attributeValue("blue", "255"));

--- a/src/net/teslaworks/visualizer/shapes/Shape.java
+++ b/src/net/teslaworks/visualizer/shapes/Shape.java
@@ -69,6 +69,6 @@ public abstract class Shape {
     // Draw this shape to the graphics2d instance
     public void paint(Graphics2D g2d, int[] channelValues) {
         g2d.setStroke(new BasicStroke(3));
-        g2d.setColor(new Color(red, green, blue, channelValues[channel]));
+        g2d.setPaint(new Color(red, green, blue, channelValues[channel]));
     }
 }

--- a/src/net/teslaworks/visualizer/shapes/Shape.java
+++ b/src/net/teslaworks/visualizer/shapes/Shape.java
@@ -78,7 +78,14 @@ public abstract class Shape {
 
     // Draw this shape to the graphics2d instance
     public void paint(Graphics2D g2d, int[] channelValues) {
+        g2d.rotate(rotation, x, y);
         g2d.setStroke(new BasicStroke(3));
         g2d.setPaint(new Color(red, green, blue, channelValues[channel]));
+
+        paintWork(g2d, channelValues);
+
+        g2d.rotate(0 - rotation, x, y);
     }
+
+    abstract protected void paintWork(Graphics2D g2d, int[] channelValues);
 }

--- a/src/net/teslaworks/visualizer/shapes/Shape.java
+++ b/src/net/teslaworks/visualizer/shapes/Shape.java
@@ -15,6 +15,7 @@ public abstract class Shape {
     // Position
     public final int x;
     public final int y;
+    public final double rotation;
 
     // Color
     public final int red;
@@ -50,8 +51,21 @@ public abstract class Shape {
         name = e.attributeValue("name");
         channel = Integer.parseInt(e.attributeValue("channel"));
 
-        x = Integer.parseInt(e.attributeValue("x"));
-        y = Integer.parseInt(e.attributeValue("y"));
+        int _x, _y;
+        double _rotation;
+
+        try { _x = Integer.parseInt(e.attributeValue("x")); }
+        catch (Exception r) { _x = 0; }
+
+        try { _y = Integer.parseInt(e.attributeValue("y")); }
+        catch (Exception r) { _y = 0; }
+
+        try { _rotation = Double.parseDouble(e.attributeValue("rotation")); }
+        catch (Exception r) { _rotation = 0; }
+
+        x = _x;
+        y = _y;
+        rotation = _rotation;
 
         red = Integer.parseInt(e.attributeValue("red", "255"));
         blue = Integer.parseInt(e.attributeValue("blue", "255"));

--- a/src/net/teslaworks/visualizer/shapes/Sunburst.java
+++ b/src/net/teslaworks/visualizer/shapes/Sunburst.java
@@ -33,8 +33,8 @@ public class Sunburst extends Shape {
     public final int originY;
     public final List<Spoke> spokes;
 
-    protected Sunburst(Element e, int xOffset, int yOffset) {
-        super(e, xOffset, yOffset);
+    protected Sunburst(Element e) {
+        super(e);
 
         width = Integer.parseInt(e.attributeValue("width"));
         height = Integer.parseInt(e.attributeValue("height"));
@@ -67,13 +67,8 @@ public class Sunburst extends Shape {
     public void paint(Graphics2D g2d, int[] channelValues) {
         super.paint(g2d, channelValues);
         for (Spoke s : spokes) {
-            g2d.setColor(new Color(
-                    s.red, s.green, s.blue, channelValues[s.channel]));
-            g2d.drawLine(
-                    originX + xOffset,
-                    originY + yOffset, 
-                    s.endX + xOffset,
-                    s.endY + yOffset);
+            g2d.setColor(new Color(s.red, s.green, s.blue, channelValues[s.channel]));
+            g2d.drawLine(originX, originY, s.endX, s.endY);
         }
     }
 

--- a/src/net/teslaworks/visualizer/shapes/Sunburst.java
+++ b/src/net/teslaworks/visualizer/shapes/Sunburst.java
@@ -64,8 +64,7 @@ public class Sunburst extends Shape {
     }
 
     // Draw this fan
-    public void paint(Graphics2D g2d, int[] channelValues) {
-        super.paint(g2d, channelValues);
+    public void paintWork(Graphics2D g2d, int[] channelValues) {
         for (Spoke s : spokes) {
             g2d.setColor(new Color(s.red, s.green, s.blue, channelValues[s.channel]));
             g2d.drawLine(originX, originY, s.endX, s.endY);

--- a/src/net/teslaworks/visualizer/shapes/Text.java
+++ b/src/net/teslaworks/visualizer/shapes/Text.java
@@ -20,8 +20,7 @@ public class Text extends Shape {
     }
 
     // Draw this rectangle
-    public void paint(Graphics2D g2d, int[] channelValues) {
-        super.paint(g2d, channelValues);
+    public void paintWork(Graphics2D g2d, int[] channelValues) {
         g2d.setFont(new Font(font, Font.PLAIN, fontSize));
         g2d.drawString(value, x, y);
     }

--- a/src/net/teslaworks/visualizer/shapes/Text.java
+++ b/src/net/teslaworks/visualizer/shapes/Text.java
@@ -12,8 +12,8 @@ public class Text extends Shape {
     public final int fontSize;
 
     // Set values unique to rectangles
-    protected Text(Element e, int xOffset, int yOffset) {
-        super(e, xOffset, yOffset);
+    protected Text(Element e) {
+        super(e);
         value = e.getTextTrim();
         font = e.attributeValue("font", "Purisa");
         fontSize = Integer.parseInt(e.attributeValue("fontSize", "12"));
@@ -23,6 +23,6 @@ public class Text extends Shape {
     public void paint(Graphics2D g2d, int[] channelValues) {
         super.paint(g2d, channelValues);
         g2d.setFont(new Font(font, Font.PLAIN, fontSize));
-        g2d.drawString(value, x + xOffset, y + yOffset);
+        g2d.drawString(value, x, y);
     }
 }


### PR DESCRIPTION
This fixes #8 (https://github.com/teslaworksumn/lightshow-visualizer/issues/8).
1. Cleans up Group translation code. Now uses the actual Graphics2D Translate API instead of manually keeping track of offsets.
2. Ensures that position attributes are read safely.
3. Adds rotation attribute to shapes and groups.
