### PR TITLE
Added shape for addressable net light.

### DIFF
--- a/config/layout15.xml
+++ b/config/layout15.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<layout>
+    <size width="800" height="240"/>
+    <channels count="16"/>
+    <background red="75" green="75" blue="75" />
+    <elements>
+        <shape type="rect" name="Channel 0" x="10" y="10" width="80" height="80" red="255" green="255" blue="255" fill="false" channel="0" />
+        <shape type="rect" name="Channel 1" x="100" y="10" width="80" height="80" red="0" green="255" blue="0" fill="true" channel="1" />
+        <shape type="rect" name="Channel 2" x="10" y="100" width="80" height="80" red="255" green="255" blue="255" fill="false" channel="2" />
+        <shape type="rect" name="Channel 3" x="100" y="100" width="80" height="80" red="0" green="255" blue="0" fill="true" channel="3" />
+        <shape type="netlight" rotation="45" name="Channel 0" x="190" y="10" width="20" height="20" xCount="5" yCount="3" gap="2" red="255" green="255" blue="255" channel="0" />
+        <shape type="snowflake" rotation="30" name="Channel 0" x="10" y="10" width="80" height="80" red="255" green="0" blue="0" channel="0" />
+    </elements>
+</layout>

--- a/config/layout15.xml
+++ b/config/layout15.xml
@@ -8,7 +8,7 @@
         <shape type="rect" name="Channel 1" x="100" y="10" width="80" height="80" red="0" green="255" blue="0" fill="true" channel="1" />
         <shape type="rect" name="Channel 2" x="10" y="100" width="80" height="80" red="255" green="255" blue="255" fill="false" channel="2" />
         <shape type="rect" name="Channel 3" x="100" y="100" width="80" height="80" red="0" green="255" blue="0" fill="true" channel="3" />
-        <shape type="netlight" rotation="45" name="Channel 0" x="190" y="10" width="20" height="20" xCount="5" yCount="3" gap="2" red="255" green="255" blue="255" channel="0" />
+        <shape type="netlight" reverse="false" name="Channel 0" x="190" y="10" width="20" height="20" xCount="5" yCount="3" gap="2" red="255" green="255" blue="255" channel="0" />
         <shape type="snowflake" rotation="30" name="Channel 0" x="10" y="10" width="80" height="80" red="255" green="0" blue="0" channel="0" />
     </elements>
 </layout>

--- a/config/layout15.xml
+++ b/config/layout15.xml
@@ -9,6 +9,6 @@
         <shape type="rect" name="Channel 2" x="10" y="100" width="80" height="80" red="255" green="255" blue="255" fill="false" channel="2" />
         <shape type="rect" name="Channel 3" x="100" y="100" width="80" height="80" red="0" green="255" blue="0" fill="true" channel="3" />
         <shape type="netlight" reverse="false" name="Channel 0" x="190" y="10" width="20" height="20" xCount="5" yCount="3" gap="2" red="255" green="255" blue="255" channel="0" />
-        <shape type="snowflake" rotation="30" name="Channel 0" x="10" y="10" width="80" height="80" red="255" green="0" blue="0" channel="0" />
+        <shape type="netlight" reverse="true" name="Channel 0" x="190" y="10" width="20" height="20" xCount="5" yCount="3" gap="2" red="0" green="255" blue="0" channel="0" />
     </elements>
 </layout>

--- a/src/net/teslaworks/visualizer/shapes/Bush.java
+++ b/src/net/teslaworks/visualizer/shapes/Bush.java
@@ -8,8 +8,6 @@ import java.awt.image.BufferedImage;
 
 public class Bush extends Shape {
 
-    private static Color TRANSPARENT = new Color(0, 0, 0, 0);
-
     // Shape size
     public final int width;
     public final int height;
@@ -40,7 +38,7 @@ public class Bush extends Shape {
 
         g2d.setPaint(dualColor
                 ? new Color(red2, green2, blue2, channelValues[channel + 1])
-                : TRANSPARENT);
+                : Shape.TRANSPARENT);
         g2d.fill(new Rectangle(4, 0, 4, 4));
         g2d.fill(new Rectangle(0, 4, 4, 4));
 

--- a/src/net/teslaworks/visualizer/shapes/NetLight.java
+++ b/src/net/teslaworks/visualizer/shapes/NetLight.java
@@ -3,31 +3,71 @@ package net.teslaworks.visualizer.shapes;
 import org.dom4j.Element;
 
 import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.awt.Rectangle;
 
 public class NetLight extends Shape {
 
     // Shape size
-    private final int width, height;
-    private final int xCount, yCount, gap;
+    private final int width, height, gap;
+    private final int xCount, yCount, count;
     private final boolean reverseCheckered;
 
     // Set values unique to rectangles
     protected NetLight(Element e) {
         super(e);
+
         width = Integer.parseInt(e.attributeValue("width"));
         height = Integer.parseInt(e.attributeValue("height"));
+        gap = Integer.parseInt(e.attributeValue("gap"));
+
         xCount = Integer.parseInt(e.attributeValue("xCount"));
         yCount = Integer.parseInt(e.attributeValue("yCount"));
-        gap = Integer.parseInt(e.attributeValue("gap"));
+        count = xCount * yCount;
         reverseCheckered = Boolean.parseBoolean(e.attributeValue("reverse"));
+    }
+
+    private TexturePaint[] makeTexturePaints(int[] channelValues) {
+        TexturePaint[] paints = new TexturePaint[count];
+
+        for (int i = 0; i < count; i++) {
+            BufferedImage image = new BufferedImage(8, 8, BufferedImage.TYPE_INT_ARGB);
+            Graphics2D g2d = image.createGraphics();
+
+            if (reverseCheckered) {
+                g2d.setPaint(new Color(red, green, blue, channelValues[channel + i]));
+                g2d.fill(new Rectangle(0, 4, 4, 4));
+                g2d.fill(new Rectangle(4, 0, 4, 4));
+
+                g2d.setPaint(Shape.TRANSPARENT);
+                g2d.fill(new Rectangle(0, 0, 4, 4));
+                g2d.fill(new Rectangle(4, 4, 4, 4));
+            }
+            else {
+                g2d.setPaint(new Color(red, green, blue, channelValues[channel + i]));
+                g2d.fill(new Rectangle(0, 0, 4, 4));
+                g2d.fill(new Rectangle(4, 4, 4, 4));
+
+                g2d.setPaint(Shape.TRANSPARENT);
+                g2d.fill(new Rectangle(0, 4, 4, 4));
+                g2d.fill(new Rectangle(4, 0, 4, 4));
+            }
+
+            paints[i] = new TexturePaint(image, new Rectangle(0, 0, 8, 8));
+            g2d.dispose();
+        }
+
+        return paints;
     }
 
     // Draw this rectangle
     public void paintWork(Graphics2D g2d, int[] channelValues) {
-        int c = channel;
+        TexturePaint[] paints = makeTexturePaints(channelValues);
+        int c = 0;
+
         for (int i = 0; i < xCount; i++) {
             for (int j = yCount - 1; j >= 0; j--) {
-                g2d.setPaint(new Color(red, green, blue, channelValues[c]));
+                g2d.setPaint(paints[c]);
                 g2d.fill(new java.awt.Rectangle(
                         x + i * (width + gap), y + j * (height + gap), width, height));
                 c++;

--- a/src/net/teslaworks/visualizer/shapes/NetLight.java
+++ b/src/net/teslaworks/visualizer/shapes/NetLight.java
@@ -1,0 +1,32 @@
+package net.teslaworks.visualizer.shapes;
+
+import org.dom4j.Element;
+
+import java.awt.*;
+
+public class NetLight extends Shape {
+
+    // Shape size
+    private final int width, height;
+    private final int xCount, yCount, gap;
+
+    // Set values unique to rectangles
+    protected NetLight(Element e) {
+        super(e);
+        width = Integer.parseInt(e.attributeValue("width"));
+        height = Integer.parseInt(e.attributeValue("height"));
+        xCount = Integer.parseInt(e.attributeValue("xCount"));
+        yCount = Integer.parseInt(e.attributeValue("yCount"));
+        gap = Integer.parseInt(e.attributeValue("gap"));
+    }
+
+    // Draw this rectangle
+    public void paintWork(Graphics2D g2d, int[] channelValues) {
+        for (int i = 0; i < xCount; i++) {
+            for (int j = 0; j < yCount; j++) {
+                g2d.fill(new java.awt.Rectangle(
+                        x + i * (width + gap), y + j * (height + gap), width, height));
+            }
+        }
+    }
+}

--- a/src/net/teslaworks/visualizer/shapes/NetLight.java
+++ b/src/net/teslaworks/visualizer/shapes/NetLight.java
@@ -9,6 +9,7 @@ public class NetLight extends Shape {
     // Shape size
     private final int width, height;
     private final int xCount, yCount, gap;
+    private final boolean reverseCheckered;
 
     // Set values unique to rectangles
     protected NetLight(Element e) {
@@ -18,14 +19,18 @@ public class NetLight extends Shape {
         xCount = Integer.parseInt(e.attributeValue("xCount"));
         yCount = Integer.parseInt(e.attributeValue("yCount"));
         gap = Integer.parseInt(e.attributeValue("gap"));
+        reverseCheckered = Boolean.parseBoolean(e.attributeValue("reverse"));
     }
 
     // Draw this rectangle
     public void paintWork(Graphics2D g2d, int[] channelValues) {
+        int c = channel;
         for (int i = 0; i < xCount; i++) {
-            for (int j = 0; j < yCount; j++) {
+            for (int j = yCount - 1; j >= 0; j--) {
+                g2d.setPaint(new Color(red, green, blue, channelValues[c]));
                 g2d.fill(new java.awt.Rectangle(
                         x + i * (width + gap), y + j * (height + gap), width, height));
+                c++;
             }
         }
     }

--- a/src/net/teslaworks/visualizer/shapes/Shape.java
+++ b/src/net/teslaworks/visualizer/shapes/Shape.java
@@ -8,6 +8,8 @@ import org.dom4j.Element;
 
 public abstract class Shape {
 
+    public static Color TRANSPARENT = new Color(0, 0, 0, 0);
+
     // DMX
     public final String name;
     public final int channel;

--- a/src/net/teslaworks/visualizer/shapes/Shape.java
+++ b/src/net/teslaworks/visualizer/shapes/Shape.java
@@ -46,6 +46,8 @@ public abstract class Shape {
             return new Bush(e);
         case "snowflake":
             return new Snowflake(e);
+        case "netlight":
+            return new NetLight(e);
         }
         throw new IllegalArgumentException("Unknown shape type: " + e.asXML());
     }


### PR DESCRIPTION
Fixes teslaworksumn#11.

This creates a grid of rectangles painted in a half-bush pattern (one half is transparent, like a Bush with dual=false). The grid is in an XY plane as in the layout below. The channels go from (0.0) (0.1) (0.2) (1.0) (1.1) ... (14.1) (14.2).

```
NOTES: The Addressable Net Light is on a 3x15 XY coordinate system
y=2 -|
     |
y=0 -+---------------
     |              |
   x=0           x=14
```

To create an actual addressable net light with two colors, create two NetLight shapes, one with reverse=true and the other with reverse=false. This is because in the DMX layout, the green and white channels for the net light aren't right next to each other.
